### PR TITLE
Avoid error when reading dictionary with int keys

### DIFF
--- a/thunderpack/formats.py
+++ b/thunderpack/formats.py
@@ -394,7 +394,7 @@ class MsgpackFormat(FileFormat):
 
     @classmethod
     def decode(cls, data: bytes) -> Any:
-        return msgpack.unpackb(data) #, raw=True)
+        return msgpack.unpackb(data, strict_map_key=False) #, raw=True)
 
 
 class PlaintextFormat(FileFormat):


### PR DESCRIPTION
When I try to retrieve a dictionary with int keys from a ThunderDB I get this error:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[4], [line 1](vscode-notebook-cell:?execution_count=4&line=1)
----> [1](vscode-notebook-cell:?execution_count=4&line=1) reader["_label_names"]

File /autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/thunder.py:101, in ThunderReader.__getitem__(self, key)
     [99](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/thunder.py:99) if data is None:
    [100](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/thunder.py:100)     raise LookupError(f"Missing {key} while reading file {str(self.path)}")
--> [101](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/thunder.py:101) return autounpackb(data)

File /autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:118, in autounpackb(data, extension)
    [116](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:116) def autounpackb(data: bytes, extension: Optional[str] = None) -> object:
    [117](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:117)     ext, _, data = data.partition(b"\x00")
--> [118](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:118)     return autodecode(data, ext.decode())

File /autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:27, in autodecode(data, filename)
     [25](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:25) ext = str(filename).partition(".")[2]
     [26](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:26) fmt = SupportedFormats.get_format(ext)
---> [27](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:27) obj = fmt.decode(data)
     [28](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:28) return obj
     [29](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/common.py:29) ext = str(filename).partition(".")[2]

File /autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/compression.py:153, in ChainedFileCompression.decode(self, data)
    [151](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/compression.py:151) def decode(self, data: bytes) -> object:
    [152](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/thunderpack/compression.py:152)     data = self.compression_format.decode(data)
...
--> [287](https://vscode-remote+ssh-002dremote-002bbhim.vscode-resource.vscode-cdn.net/autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/msgpack_numpy.py:287) return _unpackb(packed, **kwargs)

File /autofs/space/bhim_001/users/hew19/env/.conda/envs/helix2/lib/python3.9/site-packages/msgpack/_unpacker.pyx:194, in msgpack._cmsgpack.unpackb()

ValueError: int is not allowed for map key when strict_map_key=True
```

Setting `strict_map_key=False` fixes it

